### PR TITLE
[FIX] do not display default message in chat

### DIFF
--- a/Playtime.lua
+++ b/Playtime.lua
@@ -1,13 +1,52 @@
 PlaytimeDB = PlaytimeDB or {}
-local cachingPlaytime = true
 
-local o = ChatFrame_DisplayTimePlayed
-ChatFrame_DisplayTimePlayed = function(...)
-	if (cachingPlaytime) then
-		cachingPlaytime = false
-		return
+local function unregisterTimePlayedEvents()
+	local saved = {}
+	for i = 1, NUM_CHAT_WINDOWS do
+		local cf = _G["ChatFrame"..i]
+		if cf:IsEventRegistered("TIME_PLAYED_MSG") then
+			saved[i] = true
+			cf:UnregisterEvent("TIME_PLAYED_MSG")
+		end
 	end
-	return o(...)
+	return saved
+end
+
+local function restoreTimePlayedEvents(saved)
+	for i = 1, NUM_CHAT_WINDOWS do
+		if saved[i] then
+			_G["ChatFrame"..i]:RegisterEvent("TIME_PLAYED_MSG")
+		end
+	end
+end
+
+local function secondsToDays(seconds)
+	local days = math.floor(seconds / 86400)
+	local hours = math.floor((seconds % 86400) / 3600)
+	local minutes = math.floor((seconds % 3600) / 60)
+	local secs = seconds % 60
+
+	return string.format("%d days, %d hours, %d minutes, %d seconds", days, hours, minutes, secs)
+end
+
+local function savePlaytime()
+	-- prevent default TimePlayed message from being printed to chat
+	local savedEvents = unregisterTimePlayedEvents()
+	RequestTimePlayed()
+	-- restore events after a short delay to ensure we get the TIME_PLAYED_MSG event
+	C_Timer.After(0.2, function() restoreTimePlayedEvents(savedEvents) end)
+end
+
+local function showPlaytime()
+	savePlaytime()
+
+	local totaltime = 0
+	for player, time in pairs(PlaytimeDB) do
+		print(string.format("|cffaaaaaa%s|r: %s", player, secondsToDays(time)))
+		totaltime = totaltime + time
+	end
+
+	print(string.format("Total Playtime: %s", secondsToDays(totaltime)))
 end
 
 local Playtime = CreateFrame("Frame")
@@ -16,46 +55,22 @@ Playtime:RegisterEvent("PLAYER_LOGOUT")
 Playtime:RegisterEvent("TIME_PLAYED_MSG")
 
 Playtime:SetScript("OnEvent", function(self, event, ...)
-return self[event] and self[event](self, ...)
+	return self[event] and self[event](self, ...)
 end)
 
 function Playtime:PLAYER_LOGIN()
-	SavePlaytime()
+	savePlaytime()
 end
 
 function Playtime:PLAYER_LOGOUT()
-	SavePlaytime()
+	savePlaytime()
 end
 
 function Playtime:TIME_PLAYED_MSG(total, currentLevel)
-	local p = UnitName("player")	
-	local r = GetRealmName()
-	PlaytimeDB[p.." ("..r..")"] = total
-end
-
-function SavePlaytime()
-	cachingPlaytime = true
-	RequestTimePlayed()
-end
-
-function ShowPlaytime()
-	SavePlaytime()
-	
-	local totaltime = 0
-	for player,time in pairs(PlaytimeDB) do
-print("|cffaaaaaa"..player..": "..secondsToDays(time) )
-		totaltime = totaltime + time
-	end
-
-	print("Total Playtime: "..secondsToDays(totaltime) )
-end
-
-function secondsToDays(inputSeconds)
- fdays = math.floor(inputSeconds/86400)
- fhours = math.floor((bit.mod(inputSeconds,86400))/3600)
- fminutes = math.floor(bit.mod((bit.mod(inputSeconds,86400)),3600)/60)
- fseconds = math.floor(bit.mod(bit.mod((bit.mod(inputSeconds,86400)),3600),60))
- return fdays.." days, "..fhours.." hours, "..fminutes.." minutes, "..fseconds.." seconds"
+	local playerName = UnitName("player")
+	local realmName = GetRealmName()
+	local key = string.format("%s (%s)", playerName, realmName)
+	PlaytimeDB[key] = total
 end
 
 SLASH_PLAYTIME1 = '/playtime';
@@ -63,10 +78,10 @@ SLASH_PLAYTIME1 = '/playtime';
 local function handler(msg, editbox)
 	if msg and (msg == 'clear') then
 		PlaytimeDB = {}
-		SavePlaytime()
+		savePlaytime()
 	else
-		ShowPlaytime()
+		showPlaytime()
 	end
 end
 
-SlashCmdList["PLAYTIME"] = handler;
+SlashCmdList["PLAYTIME"] = handler

--- a/Playtime.toc
+++ b/Playtime.toc
@@ -1,9 +1,9 @@
-## Interface: 80100
+## Interface: 120001
 ## Author: Steven Troughton-Smith
 ## Title: Playtime
 ## Notes: Track time played for all characters
-## Version: 2
-## X-Curse-Packaged-Version: 2
+## Version: 5.1
+## X-Curse-Packaged-Version: 5.1
 ## X-Curse-Project-Name: Playtime
 
 ## SavedVariables: PlaytimeDB


### PR DESCRIPTION
ChatFrame_DisplayTmePlayed is deprecated, so the `cachingPlaytime` hack is not working anymore. I had to find another solution to prevent the default timePlayed message to be displayed in the chat